### PR TITLE
Check project for java 8 spring boot bugs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,8 +64,7 @@ subprojects {
         // SLF4J - Logging facade
         compileOnly "org.slf4j:slf4j-api:${slf4jVersion}"
         
-        // Optional: Validation API
-        compileOnly "jakarta.validation:jakarta.validation-api:${validationApiVersion}"
+        // Optional: Validation API - subprojects will define their own based on Spring Boot version
         
         // Test Dependencies
         testImplementation "org.junit.jupiter:junit-jupiter:${junitVersion}"

--- a/flowstep-spring-boot-2-starter/src/test/java/net/xrftech/flowstep/CommandTemplateTest.java
+++ b/flowstep-spring-boot-2-starter/src/test/java/net/xrftech/flowstep/CommandTemplateTest.java
@@ -115,7 +115,7 @@ class CommandTemplateTest {
 
         @Override
         protected String buildResponse(CommandContext context) {
-            return "executed: " + context.<TestCommand>get("request").getAction();
+            return "executed: " + context.<TestCommand>getCommand().getAction();
         }
     }
 }

--- a/flowstep-spring-boot-3-starter/src/test/java/net/xrftech/flowstep/CommandTemplateTest.java
+++ b/flowstep-spring-boot-3-starter/src/test/java/net/xrftech/flowstep/CommandTemplateTest.java
@@ -114,7 +114,7 @@ class CommandTemplateTest {
 
         @Override
         protected String buildResponse(CommandContext context) {
-            return "executed: " + context.<TestCommand>get("request").getAction();
+            return "executed: " + context.<TestCommand>getCommand().getAction();
         }
     }
 }


### PR DESCRIPTION
Fix test failures by correcting command context access and resolve dependency conflicts by removing a globally applied Jakarta validation API.

The parent `build.gradle` was incorrectly applying `jakarta.validation-api` (for Spring Boot 3+) to all subprojects, including the Spring Boot 2 starter which requires `javax.validation`. This change allows each subproject to declare the correct validation API for its Spring Boot version.

---
<a href="https://cursor.com/background-agent?bcId=bc-c8a186e2-63b3-4f41-b66b-07477b7b9c25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c8a186e2-63b3-4f41-b66b-07477b7b9c25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

