### PR TITLE
Apply command and query flow annotations

### DIFF
--- a/examples/spring-boot-2-example/src/main/java/net/xrftech/flowstep/example/service/CreateOrderCommandService.java
+++ b/examples/spring-boot-2-example/src/main/java/net/xrftech/flowstep/example/service/CreateOrderCommandService.java
@@ -3,6 +3,7 @@ package net.xrftech.flowstep.example.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.xrftech.flowstep.CommandTemplate;
+import net.xrftech.flowstep.annotation.CommandFlow;
 import net.xrftech.flowstep.context.CommandContext;
 import net.xrftech.flowstep.exception.ErrorType;
 import net.xrftech.flowstep.step.CommandStep;
@@ -37,6 +38,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 @Transactional  // Required for CommandTemplate operations
+@CommandFlow(code = "CREATE_ORDER", desc = "Process new customer order with multi-step validation and persistence")
 public class CreateOrderCommandService extends CommandTemplate<CreateOrderCommand, CreateOrderResponse> {
     
     private final ValidateUserStep validateUserStep;

--- a/examples/spring-boot-2-example/src/main/java/net/xrftech/flowstep/example/service/UserOrderSummaryQueryService.java
+++ b/examples/spring-boot-2-example/src/main/java/net/xrftech/flowstep/example/service/UserOrderSummaryQueryService.java
@@ -3,6 +3,7 @@ package net.xrftech.flowstep.example.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.xrftech.flowstep.QueryTemplate;
+import net.xrftech.flowstep.annotation.QueryFlow;
 import net.xrftech.flowstep.context.QueryContext;
 import net.xrftech.flowstep.exception.ErrorType;
 import net.xrftech.flowstep.step.QueryStep;
@@ -38,6 +39,7 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@QueryFlow(code = "USER_ORDER_SUMMARY", desc = "Retrieve comprehensive user order summary with statistics and top products")
 public class UserOrderSummaryQueryService extends QueryTemplate<UserOrderSummaryRequest, UserOrderSummaryResponse> {
     
     private final FetchUserStep fetchUserStep;

--- a/examples/spring-boot-3-example/src/main/java/net/xrftech/flowstep/example/service/CreateOrderCommandService.java
+++ b/examples/spring-boot-3-example/src/main/java/net/xrftech/flowstep/example/service/CreateOrderCommandService.java
@@ -3,6 +3,7 @@ package net.xrftech.flowstep.example.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.xrftech.flowstep.CommandTemplate;
+import net.xrftech.flowstep.annotation.CommandFlow;
 import net.xrftech.flowstep.context.CommandContext;
 import net.xrftech.flowstep.exception.ErrorType;
 import net.xrftech.flowstep.step.CommandStep;
@@ -37,6 +38,7 @@ import java.util.List;
 @RequiredArgsConstructor
 @Slf4j
 @Transactional  // Required for CommandTemplate operations
+@CommandFlow(code = "CREATE_ORDER", desc = "Process new customer order with multi-step validation and persistence")
 public class CreateOrderCommandService extends CommandTemplate<CreateOrderCommand, CreateOrderResponse> {
     
     private final ValidateUserStep validateUserStep;

--- a/examples/spring-boot-3-example/src/main/java/net/xrftech/flowstep/example/service/UserOrderSummaryQueryService.java
+++ b/examples/spring-boot-3-example/src/main/java/net/xrftech/flowstep/example/service/UserOrderSummaryQueryService.java
@@ -3,6 +3,7 @@ package net.xrftech.flowstep.example.service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import net.xrftech.flowstep.QueryTemplate;
+import net.xrftech.flowstep.annotation.QueryFlow;
 import net.xrftech.flowstep.context.QueryContext;
 import net.xrftech.flowstep.exception.ErrorType;
 import net.xrftech.flowstep.step.QueryStep;
@@ -38,6 +39,7 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 @Slf4j
+@QueryFlow(code = "USER_ORDER_SUMMARY", desc = "Retrieve comprehensive user order summary with statistics and top products")
 public class UserOrderSummaryQueryService extends QueryTemplate<UserOrderSummaryRequest, UserOrderSummaryResponse> {
     
     private final FetchUserStep fetchUserStep;


### PR DESCRIPTION
# ✨ Enhance Examples: Add @CommandFlow and @QueryFlow Annotations

## Summary

This PR addresses an omission in the example applications by adding the missing `@CommandFlow` and `@QueryFlow` annotations to the respective service classes in both the Spring Boot 2 and Spring Boot 3 modules. This clarifies the intended usage of these architectural markers for services extending `CommandTemplate` and `QueryTemplate`, improving the clarity and completeness of the examples.

## 🎯 Type of Change

- [ ] 📦 **Release**
- [x] 📝 **Documentation** - Enhanced example code with architectural annotations
- [ ] 🏷️ **Versioning**
- [x] ✨ **New Feature** - (Enhancement to existing examples)
- [ ] 🐛 **Bug Fix**
- [ ] 🧹 **Code Refactor**

## 📋 Changes Made

### Annotation Additions
- ✅ Added `@CommandFlow(code = "CREATE_ORDER", desc = "Process new customer order with multi-step validation and persistence")` to `CreateOrderCommandService` in `examples/spring-boot-2-example`
- ✅ Added `@QueryFlow(code = "USER_ORDER_SUMMARY", desc = "Retrieve comprehensive user order summary with statistics and top products")` to `UserOrderSummaryQueryService` in `examples/spring-boot-2-example`
- ✅ Added `@CommandFlow(code = "CREATE_ORDER", desc = "Process new customer order with multi-step validation and persistence")` to `CreateOrderCommandService` in `examples/spring-boot-3-example`
- ✅ Added `@QueryFlow(code = "USER_ORDER_SUMMARY", desc = "Retrieve comprehensive user order summary with statistics and top products")` to `UserOrderSummaryQueryService` in `examples/spring-boot-3-example`

## 🧪 Testing

- ✅ All existing unit tests pass (no changes to core logic).
- ✅ Example applications compile and run successfully with the added annotations.
- ✅ No compilation errors or warnings introduced.

## 📦 Maven Central Coordinates

N/A (This PR does not involve a release to Maven Central)

## 🎉 Release Highlights

N/A (This PR is not a release)

## ✅ Checklist

### Pre-merge Requirements
- [x] All tests pass
- [x] Build succeeds for both modules
- [x] Documentation updated consistently (example code updated)
- [ ] Version references updated everywhere (N/A)
- [ ] Git tag created with release notes (N/A)
- [ ] No SNAPSHOT references remain in source code (N/A)

### Post-merge Actions
- [ ] Publish to Maven Central staging repository (N/A)
- [ ] Verify staging repository contents (N/A)
- [ ] Release from staging to Maven Central (N/A)
- [ ] Create GitHub Release with release notes (N/A)
- [ ] Announce to Spring Boot community (N/A)

## 🚀 Next Steps After Merge

N/A (No specific post-merge steps for this example enhancement)

## 📞 Review Notes

This PR addresses an omission in the example code, making the usage of `@CommandFlow` and `@QueryFlow` annotations explicit for services extending `CommandTemplate` and `QueryTemplate`. There are no functional changes to the core library, only enhancements to the example applications for better clarity and completeness.

---

**🎯 Enhances example code clarity for FlowStep annotations!**

---
<a href="https://cursor.com/background-agent?bcId=bc-ba5ec084-d760-4152-a26f-6022bbcad290">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba5ec084-d760-4152-a26f-6022bbcad290">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

